### PR TITLE
Add an optional GraphiQL view handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Release]
 
+### [0.2.1] - 2019-02-21
+
+- Add an optional GraphiQL view handler.
+
 ### [0.2.0] - 2019-01-14
 
 - Update Tartiflette deps to 0.3.x

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include tartiflette_aiohttp/_graphiql.html

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ web.run_app(
   - **app**: Application object from aiohttp
 * **executor_http_endpoint**: Endpoint where the GraphQL Engine will be attached, by default on `/graphql`
 * **executor_http_methods**: HTTP Method where the GraphQL Engine will be attached, by default on **POST** and **GET**.
+* **graphiql_endpoint**: Endpoint where the GraphiQL page will be attached, by default there is no GraphiQL page
 
 ### Use with custom Tartiflette engine
 
@@ -158,8 +159,9 @@ web.run_app(
 **Parameters**:
 
 * **engine**: Tartiflette Engine instance
-* **executor_context**: Context which will be passed to each resolver. Be default, the context passed to each resolvers, will contain these properties.
+* **executor_context**: Context which will be passed to each resolver. Be default, the context passed to each resolvers, will contain these properties
   - **req**: Request object from aiohttp
   - **app**: Application object from aiohttp
 * **executor_http_endpoint**: Endpoint where the GraphQL Engine will be attached, by default on `/graphql`
-* **executor_http_methods**: HTTP Method where the GraphQL Engine will be attached, by default on **POST** and **GET**.
+* **executor_http_methods**: HTTP Method where the GraphQL Engine will be attached, by default on **POST** and **GET**
+* **graphiql_endpoint**: Endpoint where the GraphiQL page will be attached, by default there is no GraphiQL page

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ web.run_app(
   - **app**: Application object from aiohttp
 * **executor_http_endpoint**: Endpoint where the GraphQL Engine will be attached, by default on `/graphql`
 * **executor_http_methods**: HTTP Method where the GraphQL Engine will be attached, by default on **POST** and **GET**.
-* **graphiql_endpoint**: Endpoint where the GraphiQL page will be attached, by default there is no GraphiQL page
 
 ### Use with custom Tartiflette engine
 
@@ -164,4 +163,59 @@ web.run_app(
   - **app**: Application object from aiohttp
 * **executor_http_endpoint**: Endpoint where the GraphQL Engine will be attached, by default on `/graphql`
 * **executor_http_methods**: HTTP Method where the GraphQL Engine will be attached, by default on **POST** and **GET**
-* **graphiql_endpoint**: Endpoint where the GraphiQL page will be attached, by default there is no GraphiQL page
+
+### Enable GraphiQL handler
+
+Tartiflette allows you to set up an instance of GraphiQL easily to quickly test
+your queries. The easiest way to do that is to set the `graphiql_enabled`
+parameter to `True`. Then, you can customize your GraphiQL instance by filling
+the `graphiql_options` parameter as bellow:
+
+```python
+from aiohttp import web
+
+from tartiflette_aiohttp import register_graphql_handlers
+
+
+_SDL = """
+    type Query {
+        hello(name: String): String
+    }
+"""
+
+web.run_app(
+    register_graphql_handlers(
+        app=web.Application(),
+        engine_sdl=_SDL,
+        graphiql_enabled=True,
+        graphiql_options={  # This is optional
+            "endpoint": "/explorer",  # Default: `/graphiql`,
+            "default_query": """
+                query Hello($name: String) {
+                  hello(name: $name)
+                }
+            """,
+            "default_variables": {
+                "name": "Bob",
+            },
+            "default_headers": {
+                "Authorization": "Bearer <default_token>",
+            },
+        },
+    )
+)
+```
+
+**Parameters**:
+
+* **engine_sdl**: Contains the [Schema Definition Language](https://graphql.org/learn/schema/)
+  - Could be a string which contains the SDL
+  - Could be an array of string, which contain the SDLs
+  - Could be a path of an SDL
+  - Could be an array of paths which contain the SDLs
+* **graphiql_enabled** *(Optional[bool] = False)*: Determines whether or not we should handle a GraphiQL endpoint
+* **graphiql_options** *(Optional[dict] = None)*: Customization options for the GraphiQL instance:
+  - **endpoint** *(Optional[str] = "/graphiql")*: allows to customize the GraphiQL endpoint
+  - **default_query** *(Optional[str] = None)*: allows you to pre-fill the GraphiQL interface with a default query
+  - **default_variables** *(Optional[dict] = None)*: allows you to pre-fill the GraphiQL interface with default variables
+  - **default_headers** *(Optional[dict] = None)*: allows you to add default headers to each request sent through the GraphiQL instance

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ _TEST_REQUIRE = [
     "black==18.9b0",
 ]
 
-_VERSION = "0.2.0"
+_VERSION = "0.2.1"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 

--- a/tartiflette_aiohttp/__init__.py
+++ b/tartiflette_aiohttp/__init__.py
@@ -1,8 +1,25 @@
 from functools import partial
-from typing import List
+from typing import List, Optional
 
 from tartiflette import Engine
+
+from tartiflette_aiohttp._graphiql import graphiql_handler
 from tartiflette_aiohttp._handler import Handlers
+
+
+def _set_graphiql_handler(
+    app, graphiql_endpoint, executor_http_endpoint, executor_http_methods
+):
+    if graphiql_endpoint is not None:
+        app.router.add_route(
+            "GET",
+            graphiql_endpoint,
+            partial(
+                graphiql_handler,
+                executor_http_endpoint=executor_http_endpoint,
+                executor_http_methods=executor_http_methods,
+            ),
+        )
 
 
 def register_graphql_handlers(
@@ -13,6 +30,7 @@ def register_graphql_handlers(
     executor_http_endpoint: str = "/graphql",
     executor_http_methods: List[str] = None,
     engine: Engine = None,
+    graphiql_endpoint: Optional[str] = None,
 ):
     """register a Tartiflette Engine to an app
 
@@ -26,6 +44,7 @@ def register_graphql_handlers(
         executor_http_endpoint {str} -- Path part of the URL the graphql endpoint will listen on (default: {"/graphql"})
         executor_http_methods {list[str]} -- List of HTTP methods allowed on the endpoint (only GET and POST are supported) (default: {None})
         engine {Engine} -- An already initialized Engine (default: {None})
+        graphiql_endpoint {str} -- Add a GraphiQL view to this path if defined (default: {None})
 
     Raises:
         Exception -- On bad sdl/engine parameter combinaison.
@@ -65,6 +84,10 @@ def register_graphql_handlers(
             )
         except AttributeError:
             raise Exception("Unsupported < %s > http method" % method)
+
+    _set_graphiql_handler(
+        app, graphiql_endpoint, executor_http_endpoint, executor_http_methods
+    )
 
     return app
 

--- a/tartiflette_aiohttp/__init__.py
+++ b/tartiflette_aiohttp/__init__.py
@@ -1,38 +1,85 @@
+import json
+
 from functools import partial
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 
 from tartiflette import Engine
-
 from tartiflette_aiohttp._graphiql import graphiql_handler
 from tartiflette_aiohttp._handler import Handlers
 
 
-def _set_graphiql_handler(
-    app, graphiql_endpoint, executor_http_endpoint, executor_http_methods
-):
-    if graphiql_endpoint is not None:
-        app.router.add_route(
-            "GET",
-            graphiql_endpoint,
-            partial(
-                graphiql_handler,
-                executor_http_endpoint=executor_http_endpoint,
-                executor_http_methods=executor_http_methods,
-            ),
+def validate_and_compute_graphiql_option(
+    raw_value: Any, option_name: str, default_value: str, indent: int = 0
+) -> str:
+    if not raw_value:
+        return default_value
+
+    if not isinstance(raw_value, dict):
+        raise TypeError(
+            f"< graphiql_options.{option_name} > parameter should be a dict."
+        )
+
+    try:
+        return json.dumps(raw_value, indent=indent)
+    except Exception as e:  # pylint: disable=broad-except
+        raise ValueError(
+            f"Unable to jsonify < graphiql_options.{option_name} value. "
+            f"Error: {e}."
         )
 
 
+def _set_graphiql_handler(
+    app: "Application",
+    graphiql_enabled: bool,
+    graphiql_options: Optional[Dict[str, Any]],
+    executor_http_endpoint: str,
+    executor_http_methods: List[str],
+) -> None:
+    if not graphiql_enabled:
+        return
+
+    if graphiql_options is None:
+        graphiql_options = {}
+
+    app.router.add_route(
+        "GET",
+        graphiql_options.get("endpoint", "/graphiql"),
+        partial(
+            graphiql_handler,
+            graphiql_options={
+                "endpoint": executor_http_endpoint,
+                "query": graphiql_options.get("default_query") or "",
+                "variables": validate_and_compute_graphiql_option(
+                    graphiql_options.get("default_variables"),
+                    "default_variables",
+                    "",
+                    2,
+                ),
+                "headers": validate_and_compute_graphiql_option(
+                    graphiql_options.get("default_headers"),
+                    "default_headers",
+                    "{}",
+                ),
+                "http_method": "POST"
+                if "POST" in executor_http_methods
+                else "GET",
+            },
+        ),
+    )
+
+
 def register_graphql_handlers(
-    app,
+    app: "Application",
     engine_sdl: str = None,
     engine_schema_name: str = "default",
     executor_context: dict = None,
     executor_http_endpoint: str = "/graphql",
     executor_http_methods: List[str] = None,
     engine: Engine = None,
-    graphiql_endpoint: Optional[str] = None,
-):
-    """register a Tartiflette Engine to an app
+    graphiql_enabled: bool = False,
+    graphiql_options: Optional[Dict[str, Any]] = None,
+) -> "Application":
+    """Register a Tartiflette Engine to an app
 
     Pass a SDL or an already initialized Engine, not both, not neither.
 
@@ -44,7 +91,8 @@ def register_graphql_handlers(
         executor_http_endpoint {str} -- Path part of the URL the graphql endpoint will listen on (default: {"/graphql"})
         executor_http_methods {list[str]} -- List of HTTP methods allowed on the endpoint (only GET and POST are supported) (default: {None})
         engine {Engine} -- An already initialized Engine (default: {None})
-        graphiql_endpoint {str} -- Add a GraphiQL view to this path if defined (default: {None})
+        graphiql_enabled {bool} -- Determines whether or not we should handle a GraphiQL endpoint (default: {False})
+        graphiql_options {dict} -- Customization options for the GraphiQL instance (default: {None})
 
     Raises:
         Exception -- On bad sdl/engine parameter combinaison.
@@ -53,7 +101,7 @@ def register_graphql_handlers(
     Return:
         The app object.
     """
-
+    # pylint: disable=too-many-arguments
     if (not engine_sdl and not engine) or (engine and engine_sdl):
         raise Exception(
             "an engine OR an engine_sdl should be passed here, not both, not none"
@@ -86,7 +134,11 @@ def register_graphql_handlers(
             raise Exception("Unsupported < %s > http method" % method)
 
     _set_graphiql_handler(
-        app, graphiql_endpoint, executor_http_endpoint, executor_http_methods
+        app,
+        graphiql_enabled,
+        graphiql_options,
+        executor_http_endpoint,
+        executor_http_methods,
     )
 
     return app

--- a/tartiflette_aiohttp/_graphiql.html
+++ b/tartiflette_aiohttp/_graphiql.html
@@ -69,6 +69,19 @@
           // than present an error.
         }
       }
+
+      var defaultQuery = `${default_query}`;
+
+      var defaultVariables = `${default_variables}`;
+      if (!parameters.variables && defaultVariables !== '') {
+        parameters.variables = defaultVariables
+      }
+
+      var headers = Object.assign(JSON.parse(`${default_headers}`), {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      });
+
       // When the query and variables string is edited, update the URL bar so
       // that it can be easily shared
       function onEditQuery(newQuery) {
@@ -99,12 +112,9 @@
         // This example expects a GraphQL server at the path /graphql.
         // Change this to point wherever you host your GraphQL server.
         if ('${http_method}' == 'POST') {
-          return fetch('${endpoint_url}', {
+          return fetch('${endpoint}', {
             method: 'POST',
-            headers: {
-              'Accept': 'application/json',
-              'Content-Type': 'application/json',
-            },
+            headers: headers,
             body: JSON.stringify(graphQLParams),
             credentials: 'include',
           }).then(function (response) {
@@ -118,12 +128,9 @@
           });
         }
         else {
-          return fetch('${endpoint_url}?' + serialize(graphQLParams), {
+          return fetch('${endpoint}?' + serialize(graphQLParams), {
             method: 'GET',
-            headers: {
-              'Accept': 'application/json',
-              'Content-Type': 'application/json',
-            },
+            headers: headers,
             credentials: 'include',
           }).then(function (response) {
             return response.text();
@@ -143,7 +150,7 @@
       ReactDOM.render(
         React.createElement(GraphiQL, {
           fetcher: graphQLFetcher,
-          query: parameters.query,
+          query: parameters.query || (defaultQuery !== '' ? defaultQuery : undefined),
           variables: parameters.variables,
           operationName: parameters.operationName,
           onEditQuery: onEditQuery,

--- a/tartiflette_aiohttp/_graphiql.html
+++ b/tartiflette_aiohttp/_graphiql.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+
+    <meta charset="utf-8" />
+    <title>GraphiQL</title>
+    <meta name="robots" content="noindex" />
+    <link href="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.css" rel="stylesheet">
+    <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
+    <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.js"></script>
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script>
+      serialize = function(obj, prefix) {
+        var str = [],
+          p;
+        for (p in obj) {
+          if (obj.hasOwnProperty(p)) {
+            var k = prefix ? prefix + "[" + p + "]" : p,
+              v = obj[p];
+            str.push((v !== null && typeof v === "object") ?
+              serialize(v, k) :
+              encodeURIComponent(k) + "=" + encodeURIComponent(v));
+          }
+        }
+        return str.join("&");
+      }
+
+      /**
+       * This GraphiQL example illustrates how to use some of GraphiQL's props
+       * in order to enable reading and updating the URL parameters, making
+       * link sharing of queries a little bit easier.
+       *
+       * This is only one example of this kind of feature, GraphiQL exposes
+       * various React params to enable interesting integrations.
+       */
+      // Parse the search string to get url parameters.
+      var search = window.location.search;
+      var parameters = {};
+      search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] =
+            decodeURIComponent(entry.slice(eq + 1));
+        }
+      });
+      // if variables was provided, try to format it.
+      if (parameters.variables) {
+        try {
+          parameters.variables =
+            JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+          // Do nothing, we want to display the invalid JSON as a string, rather
+          // than present an error.
+        }
+      }
+      // When the query and variables string is edited, update the URL bar so
+      // that it can be easily shared
+      function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+      }
+      function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+      }
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
+      function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+          return Boolean(parameters[key]);
+        }).map(function (key) {
+          return encodeURIComponent(key) + '=' +
+            encodeURIComponent(parameters[key]);
+        }).join('&');
+        history.replaceState(null, null, newSearch);
+      }
+      // Defines a GraphQL fetcher using the fetch API. You're not required to
+      // use fetch, and could instead implement graphQLFetcher however you like,
+      // as long as it returns a Promise or Observable.
+      function graphQLFetcher(graphQLParams) {
+        // This example expects a GraphQL server at the path /graphql.
+        // Change this to point wherever you host your GraphQL server.
+        if ('${http_method}' == 'POST') {
+          return fetch('${endpoint_url}', {
+            method: 'POST',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(graphQLParams),
+            credentials: 'include',
+          }).then(function (response) {
+            return response.text();
+          }).then(function (responseBody) {
+            try {
+              return JSON.parse(responseBody);
+            } catch (error) {
+              return responseBody;
+            }
+          });
+        }
+        else {
+          return fetch('${endpoint_url}?' + serialize(graphQLParams), {
+            method: 'GET',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+          }).then(function (response) {
+            return response.text();
+          }).then(function (responseBody) {
+            try {
+              return JSON.parse(responseBody);
+            } catch (error) {
+              return responseBody;
+            }
+          });
+        }
+      }
+      // Render <GraphiQL /> into the body.
+      // See the README in the top level of this module to learn more about
+      // how you can customize GraphiQL by providing different values or
+      // additional child elements.
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: graphQLFetcher,
+          query: parameters.query,
+          variables: parameters.variables,
+          operationName: parameters.operationName,
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables,
+          onEditOperationName: onEditOperationName
+        }),
+        document.getElementById('graphiql')
+      );
+    </script>
+  </body>
+</html>

--- a/tartiflette_aiohttp/_graphiql.py
+++ b/tartiflette_aiohttp/_graphiql.py
@@ -1,0 +1,27 @@
+from string import Template
+
+import pkg_resources
+
+from aiohttp import web
+
+
+_GRAPHIQL_TEMPLATE = pkg_resources.resource_string(
+    __name__, "_graphiql.html"
+).decode("utf-8")
+
+
+async def graphiql_handler(
+    request, executor_http_endpoint, executor_http_methods
+):
+    # pylint: disable=unused-argument
+    return web.Response(
+        text=_render_graphiql(executor_http_endpoint, executor_http_methods),
+        headers={"Content-Type": "text/html"},
+    )
+
+
+def _render_graphiql(executor_http_endpoint, executor_http_methods):
+    return Template(_GRAPHIQL_TEMPLATE).substitute(
+        endpoint_url=executor_http_endpoint,
+        http_method=("POST" if "POST" in executor_http_methods else "GET"),
+    )

--- a/tartiflette_aiohttp/_graphiql.py
+++ b/tartiflette_aiohttp/_graphiql.py
@@ -1,9 +1,9 @@
 import os
 
 from string import Template
+from typing import Dict, Any
 
 from aiohttp import web
-
 
 try:
     _TTFTT_AIOHTTP_DIR = os.path.dirname(__file__)
@@ -15,17 +15,20 @@ except Exception as e:  # pylint: disable=broad-except
 
 
 async def graphiql_handler(
-    request, executor_http_endpoint, executor_http_methods
-):
+    request, graphiql_options: Dict[str, Any]
+) -> "Response":
     # pylint: disable=unused-argument
     return web.Response(
-        text=_render_graphiql(executor_http_endpoint, executor_http_methods),
+        text=_render_graphiql(graphiql_options),
         headers={"Content-Type": "text/html"},
     )
 
 
-def _render_graphiql(executor_http_endpoint, executor_http_methods):
+def _render_graphiql(graphiql_options: Dict[str, Any]) -> str:
     return Template(_GRAPHIQL_TEMPLATE).substitute(
-        endpoint_url=executor_http_endpoint,
-        http_method=("POST" if "POST" in executor_http_methods else "GET"),
+        endpoint=graphiql_options["endpoint"],
+        http_method=graphiql_options["http_method"],
+        default_query=graphiql_options["query"],
+        default_variables=graphiql_options["variables"],
+        default_headers=graphiql_options["headers"],
     )

--- a/tartiflette_aiohttp/_graphiql.py
+++ b/tartiflette_aiohttp/_graphiql.py
@@ -1,13 +1,17 @@
-from string import Template
+import os
 
-import pkg_resources
+from string import Template
 
 from aiohttp import web
 
 
-_GRAPHIQL_TEMPLATE = pkg_resources.resource_string(
-    __name__, "_graphiql.html"
-).decode("utf-8")
+try:
+    _TTFTT_AIOHTTP_DIR = os.path.dirname(__file__)
+
+    with open(os.path.join(_TTFTT_AIOHTTP_DIR, "_graphiql.html")) as tpl_file:
+        _GRAPHIQL_TEMPLATE = tpl_file.read()
+except Exception as e:  # pylint: disable=broad-except
+    _GRAPHIQL_TEMPLATE = ""
 
 
 async def graphiql_handler(


### PR DESCRIPTION
The goal is to provide an easy way to integrate a GraphiQL view to call the GraphQL engine.

In order to do that, this implementation add an optional `graphiql_endpoint` parameter which, when defined, will target to a GraphiQL page instance with proper settings.