### PR TITLE
Exclude tartiflette==0.7.0 from install packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Release]
 
+### [0.6.1] - 2019-04-04
+
+#### Changed
+
+- Excludes `tartiflette==0.7.0` which contains a major bug.
+
 ### [0.6.0] - 2019-04-02
 
 #### Changed

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ _TEST_REQUIRE = [
     "black==19.3b0",
 ]
 
-_VERSION = "0.6.0"
+_VERSION = "0.6.1"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 
@@ -33,7 +33,7 @@ setup(
     ],
     keywords="api graphql protocol api rest relay tartiflette dailymotion",
     packages=_PACKAGES,
-    install_requires=["aiohttp~=3.4", "tartiflette<0.8.0,>=0.6.5"],
+    install_requires=["aiohttp~=3.4", "tartiflette<0.8.0,>=0.6.5,!=0.7.0"],
     tests_require=_TEST_REQUIRE,
     extras_require={"test": _TEST_REQUIRE},
     include_package_data=True,


### PR DESCRIPTION
We should exclude `tartiflette==0.7.0` from `install_requires` since this version of Tartiflette does include a major bug (cf. https://github.com/dailymotion/tartiflette/issues/188).

This prevents the installation of an unstable version.